### PR TITLE
feat: reflect to BLE mesh and add v2 packets

### DIFF
--- a/src/modules/BitChatBLEBridge.cpp
+++ b/src/modules/BitChatBLEBridge.cpp
@@ -476,7 +476,8 @@ void BitChatBLEBridge::onBitChatWrite(const uint8_t* data, size_t length)
         
         // Forward to bridge module for processing
         if (bitchatBridgeModule) {
-            bitchatBridgeModule->processBitChatMessage(msg, true); // fromBLE = true
+            // Queue for processing in main thread to avoid stack overflow in BLE callback
+            bitchatBridgeModule->queueMessageForProcessing(msg, true);
         }
         return;
     }
@@ -556,7 +557,8 @@ void BitChatBLEBridge::onBitChatConnect()
 {
     // Send an immediate announcement via Peripheral notify when Android/iOS connects
     if (bridgeModule) {
-        bridgeModule->sendPeerAnnouncement();
+        // Request announcement from main thread to avoid stack overflow in BLE callback
+        bridgeModule->requestPeerAnnouncement();
     }
 }
 

--- a/src/modules/BitChatBLEBridge.cpp
+++ b/src/modules/BitChatBLEBridge.cpp
@@ -499,7 +499,12 @@ void BitChatBLEBridge::onBitChatWrite(const uint8_t* data, size_t length, uint16
     }
     
     // Try to parse directly first
-    LOG_DEBUG("BitChat BLE: Received data %d bytes from handle %d", length, connHandle);
+    LOG_INFO("BitChat BLE: Received data %d bytes from handle %d", length, connHandle);
+    if (length >= 16) {
+        LOG_INFO("Raw Header: %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x",
+                 data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7],
+                 data[8], data[9], data[10], data[11], data[12], data[13], data[14], data[15]);
+    }
     BitChatMessage msg;
     if (BitChatProtocolHandler::parseMessage(data, length, msg)) {
         // Success! Complete message received in one write

--- a/src/modules/BitChatBLEBridge.cpp
+++ b/src/modules/BitChatBLEBridge.cpp
@@ -21,12 +21,24 @@ static BitChatBLEBridge* activeBridge = nullptr;
  */
 class BitChatBLECharacteristicCallbacks : public NimBLECharacteristicCallbacks {
 public:
+#ifdef NIMBLE_TWO
+    void onWrite(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo) override {
+        if (activeBridge) {
+            auto value = pCharacteristic->getValue();
+            activeBridge->onBitChatWrite(reinterpret_cast<const uint8_t*>(value.data()), value.length(), connInfo.getConnHandle());
+        }
+    }
+#else
     void onWrite(NimBLECharacteristic* pCharacteristic) override {
         if (activeBridge) {
             auto value = pCharacteristic->getValue();
-            activeBridge->onBitChatWrite(reinterpret_cast<const uint8_t*>(value.data()), value.length());
+            // On older NimBLE, connection handle isn't provided directly in onWrite.
+            // Workaround: Use the tracked handle if there is exactly one connection.
+            uint16_t handle = activeBridge->getSingleConnectionHandle();
+            activeBridge->onBitChatWrite(reinterpret_cast<const uint8_t*>(value.data()), value.length(), handle);
         }
     }
+#endif
 
     void onRead(NimBLECharacteristic* pCharacteristic) override {
         LOG_INFO("BitChat BLE: Characteristic READ by client");
@@ -37,13 +49,17 @@ public:
     
     void onSubscribe(NimBLECharacteristic* pCharacteristic, ble_gap_conn_desc* desc, uint16_t subValue) override {
         if (subValue == 1) {
-            LOG_INFO("BitChat BLE: Client SUBSCRIBED to notifications");
+            LOG_INFO("BitChat BLE: Client SUBSCRIBED to notifications (handle=%d)", desc->conn_handle);
             if (activeBridge) {
+                // Track this connection
+                activeBridge->addConnection(desc->conn_handle);
                 activeBridge->onBitChatConnect();
             }
         } else if (subValue == 0) {
-            LOG_INFO("BitChat BLE: Client UNSUBSCRIBED from notifications");
+            LOG_INFO("BitChat BLE: Client UNSUBSCRIBED from notifications (handle=%d)", desc->conn_handle);
             if (activeBridge) {
+                // Remove tracked connection
+                activeBridge->removeConnection(desc->conn_handle);
                 activeBridge->onBitChatDisconnect();
             }
         }
@@ -65,6 +81,10 @@ public:
     void onDisconnect(NimBLEServer* pServer) override {
         LOG_INFO("BitChat BLE: Client DISCONNECTED from BitChat service");
         if (activeBridge) {
+            // Check connected count to clean up
+            if (pServer->getConnectedCount() == 0) {
+                activeBridge->clearConnections();
+            }
             activeBridge->onBitChatDisconnect();
         }
     }
@@ -89,7 +109,7 @@ static BitChatBLEBridge* activeBridge = nullptr;
 void bitchat_characteristic_write_callback(uint16_t conn_hdl, BLECharacteristic* chr, uint8_t* data, uint16_t len)
 {
     if (activeBridge) {
-        activeBridge->onBitChatWrite(data, len);
+        activeBridge->onBitChatWrite(data, len, conn_hdl);
     }
 }
 
@@ -367,17 +387,23 @@ void BitChatBLEBridge::stopAdvertising()
 
 void BitChatBLEBridge::broadcastMessage(const BitChatMessage& msg)
 {
+    // Broadcast sends to ALL connected devices (no handle filtering)
+    unicastMessage(0xFFFF, msg);
+}
+
+void BitChatBLEBridge::unicastMessage(uint16_t connHandle, const BitChatMessage& msg)
+{
     if (!serviceActive) {
-        LOG_WARN("BitChat BLE: Cannot broadcast - service not active");
+        LOG_WARN("BitChat BLE: Cannot send - service not active");
         return;
     }
     
     // Serialize BitChat message once
-    uint8_t buffer[BITCHAT_HEADER_SIZE + BITCHAT_MAX_PAYLOAD_SIZE];
+    uint8_t buffer[BITCHAT_MAX_MESSAGE_SIZE];
     size_t messageSize = BitChatProtocolHandler::serializeMessage(msg, buffer, sizeof(buffer));
     
     if (messageSize == 0) {
-        LOG_ERROR("BitChat BLE: Failed to serialize message for broadcast");
+        LOG_ERROR("BitChat BLE: Failed to serialize message for send");
         return;
     }
     
@@ -386,61 +412,72 @@ void BitChatBLEBridge::broadcastMessage(const BitChatMessage& msg)
     
     try {
         if (!bitchatCharacteristic) {
-            LOG_WARN("BitChat BLE: Cannot broadcast - characteristic not initialized");
+            LOG_WARN("BitChat BLE: Cannot send - characteristic not initialized");
             return;
         }
-                // Set characteristic value and notify (Peripheral role - to connected centrals)
-        // This ensures the announcement is available even if the client doesn't subscribe to notifications
-        bitchatCharacteristic->setValue(buffer, messageSize);
-        bitchatCharacteristic->notify();
         
-        LOG_DEBUG("BitChat BLE: ESP32 broadcasted message type=0x%02x, %d bytes (set value + notify)", msg.type, messageSize);
+        // Set characteristic value (for Read requests)
+        bitchatCharacteristic->setValue(buffer, messageSize);
+        
+        // Send Notification
+        if (connHandle == 0xFFFF) {
+            // Broadcast to all subscribed clients
+            bitchatCharacteristic->notify();
+            LOG_DEBUG("BitChat BLE: ESP32 broadcasted message type=0x%02x, %d bytes", msg.type, messageSize);
+        } else {
+            // Unicast to specific connection
+#ifdef NIMBLE_TWO
+            bitchatCharacteristic->notify(buffer, messageSize, true, connHandle);
+            LOG_DEBUG("BitChat BLE: ESP32 unicast to handle %d, %d bytes", connHandle, messageSize);
+#else
+            // Old API doesn't support targeted notify easily?
+            // Fallback to broadcast or check if we can filter
+            // NimBLECharacteristic::notify() usually sends to all subscribed.
+            // If we can't target, we must broadcast.
+            bitchatCharacteristic->notify(); 
+            LOG_WARN("BitChat BLE: ESP32 unicast fallback to broadcast (old API)");
+#endif
+        }
         
     } catch (const std::exception& e) {
-        LOG_ERROR("BitChat BLE: Exception during message broadcast: %s", e.what());
+        LOG_ERROR("BitChat BLE: Exception during message send: %s", e.what());
     }
     
 #elif defined(ARCH_NRF52)
-    // Broadcast on ALL links (like iOS and Android do):
-    // 1. Peripheral role: notify subscribed centrals (devices connected to us)
-    // 2. Central role: write to connected peripherals (devices we're connected to)
-    
-    // 1. Send via Peripheral role (notify subscribed centrals)
     if (!bitchatCharacteristic) {
-        LOG_WARN("BitChat BLE: Cannot broadcast - characteristic not initialized");
+        LOG_WARN("BitChat BLE: Cannot send - characteristic not initialized");
         return;
     }
 
-    // BLE notifications are limited by MTU (MTU - 3 bytes for ATT header)
+    // BLE notifications are limited by MTU
     size_t peripheralLimit = getPeripheralNotificationLimit();
     
     if (messageSize > peripheralLimit) {
-        // Message is too large for a single notification
-        // Skip notification and send via Central write instead
-        // Android should buffer Central writes, allowing large messages to be received
         LOG_WARN("BitChat BLE: Message %d bytes > %zu (peripheral MTU payload limit), skipping notify",
                  messageSize, peripheralLimit);
-        LOG_WARN("BitChat BLE: Android should receive this via Central write (if connected)");
-        // Don't send via notify - let Central write handle it below
+        // We can't send this large message via notify.
+        // Android/iOS might read it if we set value, but notify is how push works.
+        // Fragmentation should have handled this?
+        // No, BitChat fragmentation is for Mesh. BLE MTU is separate.
+        // But we can't easily fragment at BLE level without a protocol.
+        // We just drop/warn for now if it exceeds MTU.
     } else {
-        // Message fits in single notification - send directly
         bitchatCharacteristic->write(buffer, messageSize);
-        bool notifyResult = bitchatCharacteristic->notify(buffer, messageSize);
-        if (notifyResult) {
-            LOG_DEBUG("BitChat BLE: Sent via Peripheral notify, %d bytes", messageSize);
+        
+        if (connHandle == 0xFFFF) {
+            // Broadcast
+            bool notifyResult = bitchatCharacteristic->notify(buffer, messageSize);
+            LOG_DEBUG("BitChat BLE: nRF52 broadcast result=%d", notifyResult);
         } else {
-            LOG_DEBUG("BitChat BLE: notify() returned false (client may not have enabled notifications yet), %d bytes", messageSize);
+            // Unicast using notify(conn_hdl, ...)
+            bool notifyResult = bitchatCharacteristic->notify(connHandle, buffer, messageSize);
+            LOG_DEBUG("BitChat BLE: nRF52 unicast to %d result=%d", connHandle, notifyResult);
         }
     }
-    
-#endif
-
-#ifdef ARCH_NRF52
-    LOG_DEBUG("BitChat BLE: nRF52 broadcasted message type=0x%02x, %d bytes", msg.type, messageSize);
 #endif
 }
 
-void BitChatBLEBridge::onBitChatWrite(const uint8_t* data, size_t length)
+void BitChatBLEBridge::onBitChatWrite(const uint8_t* data, size_t length, uint16_t connHandle)
 {
     uint32_t currentTime = millis();
     
@@ -451,9 +488,10 @@ void BitChatBLEBridge::onBitChatWrite(const uint8_t* data, size_t length)
     }
     
     // Check if this looks like the START of a new message (has valid header)
-    // If the incoming data has a valid BitChat header (length >= 12 bytes),
-    // and we already have buffered data, this is a NEW message
-    if (length >= BITCHAT_HEADER_SIZE && writeBufferOffset > 0) {
+    // We check V1 (13) and V2 (16) minimums.
+    size_t minHeader = BITCHAT_HEADER_SIZE_V1;
+    
+    if (length >= minHeader && writeBufferOffset > 0) {
         // This looks like a new message header while we have buffered data
         // Discard the old buffer and start fresh with this new message
         LOG_WARN("BitChat BLE: New message header detected, discarding %d buffered bytes", writeBufferOffset);
@@ -461,7 +499,7 @@ void BitChatBLEBridge::onBitChatWrite(const uint8_t* data, size_t length)
     }
     
     // Try to parse directly first
-    LOG_DEBUG("BitChat BLE: Received data %d bytes", length);
+    LOG_DEBUG("BitChat BLE: Received data %d bytes from handle %d", length, connHandle);
     BitChatMessage msg;
     if (BitChatProtocolHandler::parseMessage(data, length, msg)) {
         // Success! Complete message received in one write
@@ -470,14 +508,13 @@ void BitChatBLEBridge::onBitChatWrite(const uint8_t* data, size_t length)
         // Validate message
         if (!BitChatProtocolHandler::validateMessage(msg)) {
             LOG_WARN("BitChat BLE: Invalid message received via BLE (type=0x%02x)", msg.type);
-            // Message was parsed but invalid - just drop it
             return;
         }
         
         // Forward to bridge module for processing
         if (bitchatBridgeModule) {
-            // Queue for processing in main thread to avoid stack overflow in BLE callback
-            bitchatBridgeModule->queueMessageForProcessing(msg, true);
+            // Queue for processing in main thread
+            bitchatBridgeModule->queueMessageForProcessing(msg, true, connHandle);
         }
         return;
     }
@@ -487,13 +524,11 @@ void BitChatBLEBridge::onBitChatWrite(const uint8_t* data, size_t length)
     
     // Check if adding this would overflow
     if (writeBufferOffset + length > sizeof(writeBuffer)) {
-        LOG_ERROR("BitChat BLE: Buffer would overflow (%d + %d > %d), discarding buffer and starting fresh",
+        LOG_ERROR("BitChat BLE: Buffer would overflow (%d + %d > %d), discarding buffer",
                   writeBufferOffset, length, sizeof(writeBuffer));
         writeBufferOffset = 0;
         
-        // If this single write is too large, just drop it
         if (length > sizeof(writeBuffer)) {
-            LOG_ERROR("BitChat BLE: Single write too large (%d bytes), dropping", length);
             return;
         }
     }
@@ -508,41 +543,26 @@ void BitChatBLEBridge::onBitChatWrite(const uint8_t* data, size_t length)
         // Success!
         LOG_INFO("BitChat BLE: Reassembled message from %d bytes", writeBufferOffset);
         
-        // Calculate actual message size for buffer cleanup
-        bool hasRecipient = (msg.flags & BITCHAT_FLAG_HAS_RECIPIENT) != 0;
-        bool hasSignature = (msg.flags & BITCHAT_FLAG_HAS_SIGNATURE) != 0;
-        size_t messageSize = BITCHAT_HEADER_SIZE + 8 + (hasRecipient ? 8 : 0) + msg.payloadLength + (hasSignature ? BITCHAT_SIGNATURE_SIZE : 0);
+        // Calculate message size
+        // We can't rely on fixed calculation since header is variable.
+        // But parseMessage succeeded, so we know it's valid.
+        // We should clear the buffer.
         
         // Validate message
         if (!BitChatProtocolHandler::validateMessage(msg)) {
             LOG_WARN("BitChat BLE: Invalid message received via BLE (type=0x%02x)", msg.type);
-            // Skip past this invalid message if there's more data
-            if (messageSize < writeBufferOffset) {
-                size_t remainingBytes = writeBufferOffset - messageSize;
-                memmove(writeBuffer, writeBuffer + messageSize, remainingBytes);
-                writeBufferOffset = remainingBytes;
-                LOG_DEBUG("BitChat BLE: Skipped invalid message, %d bytes remaining", writeBufferOffset);
-                // Try parsing again
-                if (BitChatProtocolHandler::parseMessage(writeBuffer, writeBufferOffset, msg)) {
-                    if (BitChatProtocolHandler::validateMessage(msg) && bitchatBridgeModule) {
-                        bitchatBridgeModule->queueMessageForProcessing(msg, true);
-                    }
-                    writeBufferOffset = 0;
-                }
-            } else {
-                writeBufferOffset = 0;
-            }
+            // Reset buffer
+            writeBufferOffset = 0;
             return;
         }
         
         writeBufferOffset = 0;
         
-        // Queue message for deferred processing in main loop (avoid stack overflow in callback)
         if (bitchatBridgeModule) {
-            bitchatBridgeModule->queueMessageForProcessing(msg, true); // fromBLE = true
+            bitchatBridgeModule->queueMessageForProcessing(msg, true, connHandle);
         }
     } else {
-        // Still incomplete, wait for more data
+        // Still incomplete
         LOG_DEBUG("BitChat BLE: Waiting for more data (buffered %d bytes)", writeBufferOffset);
     }
 }

--- a/src/modules/BitChatBridgeModule.cpp
+++ b/src/modules/BitChatBridgeModule.cpp
@@ -648,7 +648,8 @@ BitChatMessage BitChatBridgeModule::createPeerAnnouncement()
     BitChatMessage msg;
     
     msg.type = BITCHAT_MSG_ANNOUNCE;
-    msg.senderId = static_cast<uint64_t>(myBitChatPeerId);
+    msg.senderId = static_cast<uint64_t>(myBitChatPeerId) << 32;
+
     // Timestamp in milliseconds since epoch (iOS format)
     // Use synced time if available, otherwise use device time (will be rejected by iOS)
     uint64_t deviceTimeMs = static_cast<uint64_t>(getTime()) * 1000ULL;
@@ -714,7 +715,7 @@ BitChatMessage BitChatBridgeModule::createPeerAnnouncement()
             
             for (uint8_t i = 0; i < neighborCount; i++) {
                 uint64_t id = neighborIds[i];
-                memcpy(msg.payload + offset, &id, 8);
+                memcpy(msg.payload + offset, &id, sizeof(id));
                 offset += 8;
                 LOG_DEBUG("BitChat Bridge: Announcement includes neighbor ID 0x%08x", (uint64_t)id);
             }

--- a/src/modules/BitChatBridgeModule.cpp
+++ b/src/modules/BitChatBridgeModule.cpp
@@ -634,6 +634,9 @@ void BitChatBridgeModule::sendPeerAnnouncement()
     // Broadcast via BLE - broadcastMessage() now handles both Peripheral and Central roles
     // This matches iOS sendOnAllLinks() behavior - sends on all available BLE links
     broadcastToBLE(announcement);
+
+    announcement.ttl++;
+    relayToMesh(announcement);
 }
 
 /**

--- a/src/modules/BitChatBridgeModule.cpp
+++ b/src/modules/BitChatBridgeModule.cpp
@@ -237,7 +237,7 @@ void BitChatBridgeModule::processBitChatMessage(BitChatMessage& msg, bool fromBL
             uint64_t senderId = msg.senderId;
             if (bleConnHandle != 0xFFFF) {
                 topologyManager.updateNeighbor(senderId, bleConnHandle, true);
-                LOG_INFO("BitChat Bridge: Registered direct neighbor 0x%08x (handle=%d)", senderId, bleConnHandle);
+                LOG_INFO("BitChat Bridge: Registered direct neighbor 0x%08x (handle=%hd)", senderId, bleConnHandle);
             }
         }
     }
@@ -487,7 +487,7 @@ void BitChatBridgeModule::logMessage(const BitChatMessage& msg, const char* acti
     }
     
     LOG_DEBUG("BitChat Bridge: %s - Type: %s, Sender: 0x%08x, TTL: %d, Payload: %d bytes",
-              action, typeStr, msg.senderId, msg.ttl, msg.payloadLength);
+              action, typeStr, (uint32_t)msg.senderId, msg.ttl, msg.payloadLength);
 }
 
 bool BitChatBridgeModule::handleConfigMessage(const meshtastic_AdminMessage* request, meshtastic_AdminMessage* response)
@@ -715,11 +715,9 @@ BitChatMessage BitChatBridgeModule::createPeerAnnouncement()
             
             for (uint8_t i = 0; i < neighborCount; i++) {
                 uint64_t id = neighborIds[i];
-                // Serialize 8-byte ID (Big Endian to match protocol)
-                for (int b = 7; b >= 0; b--) {
-                    msg.payload[offset++] = (id >> (b * 8)) & 0xFF;
-                }
-                LOG_DEBUG("BitChat Bridge: Announcement includes neighbor ID 0x%08x", (uint32_t)id);
+                memcpy(msg.payload + offset, &id, 8);
+                offset += 8;
+                LOG_DEBUG("BitChat Bridge: Announcement includes neighbor ID 0x%08x", (uint64_t)id);
             }
             LOG_DEBUG("BitChat Bridge: Added %d neighbors to announcement", neighborCount);
         } else {

--- a/src/modules/BitChatBridgeModule.cpp
+++ b/src/modules/BitChatBridgeModule.cpp
@@ -163,6 +163,14 @@ int32_t BitChatBridgeModule::runOnce()
     #if !MESHTASTIC_EXCLUDE_BLUETOOTH
     if (bleEnabled && bleServiceSetup) {
         uint32_t currentTime = millis();
+        
+        // Check for requested announcement (from BLE connection)
+        if (shouldSendAnnouncement) {
+            sendPeerAnnouncement();
+            shouldSendAnnouncement = false;
+            lastAnnounceTime = currentTime; // Reset periodic timer
+        }
+        
         if (currentTime - lastAnnounceTime >= ANNOUNCE_INTERVAL_MS) {
             sendPeerAnnouncement();
             lastAnnounceTime = currentTime;
@@ -585,6 +593,16 @@ bool BitChatBridgeModule::handleFragment(const BitChatMessage& fragment)
     
     // Add to reassembly buffer
     return fragmentBuffer.addFragment(fragment, fragmentId, index, total, originalSize);
+}
+
+/**
+ * Request a peer announcement to be sent from the main loop
+ * Safe to call from BLE callbacks (avoids stack overflow)
+ */
+void BitChatBridgeModule::requestPeerAnnouncement()
+{
+    shouldSendAnnouncement = true;
+    setIntervalFromNow(0); // Wake up runOnce immediately
 }
 
 /**

--- a/src/modules/BitChatBridgeModule.cpp
+++ b/src/modules/BitChatBridgeModule.cpp
@@ -188,12 +188,15 @@ int32_t BitChatBridgeModule::runOnce()
         QueuedMessage queued = messageQueue[messageQueueHead];
         messageQueueHead = (messageQueueHead + 1) % MAX_QUEUE_SIZE;
         messageQueueCount--;
-        processBitChatMessage(queued.msg, queued.fromBLE);
+        processBitChatMessage(queued.msg, queued.fromBLE, queued.bleConnHandle);
         processed++;
     }
     
     // Update statistics and cleanup
     updateStatistics();
+    
+    // Clean up stale topology entries
+    topologyManager.cleanup(millis());
     
     // If we have queued messages, run more frequently to process them quickly
     // Otherwise, run every 5 seconds during normal operation
@@ -203,7 +206,7 @@ int32_t BitChatBridgeModule::runOnce()
     return 5000;
 }
 
-void BitChatBridgeModule::queueMessageForProcessing(const BitChatMessage& msg, bool fromBLE)
+void BitChatBridgeModule::queueMessageForProcessing(const BitChatMessage& msg, bool fromBLE, uint16_t bleConnHandle)
 {
     // Queue message for deferred processing in main loop
     // This prevents stack overflow when called from BLE callbacks
@@ -218,13 +221,26 @@ void BitChatBridgeModule::queueMessageForProcessing(const BitChatMessage& msg, b
     // Add new message
     messageQueue[messageQueueTail].msg = msg;
     messageQueue[messageQueueTail].fromBLE = fromBLE;
+    messageQueue[messageQueueTail].bleConnHandle = bleConnHandle;
     messageQueueTail = (messageQueueTail + 1) % MAX_QUEUE_SIZE;
     messageQueueCount++;
 }
 
-void BitChatBridgeModule::processBitChatMessage(BitChatMessage& msg, bool fromBLE)
+void BitChatBridgeModule::processBitChatMessage(BitChatMessage& msg, bool fromBLE, uint16_t bleConnHandle)
 {
     logMessage(msg, fromBLE ? "BLE->Mesh" : "Mesh->BLE");
+    
+    // Update topology if it's a direct ANNOUNCE from BLE
+    if (fromBLE && msg.type == BITCHAT_MSG_ANNOUNCE) {
+        // TTL=7 implies direct neighbor (0 hops)
+        if (msg.ttl == 7) {
+            uint32_t senderId = msg.getSenderId32();
+            if (bleConnHandle != 0xFFFF) {
+                topologyManager.updateNeighbor(senderId, bleConnHandle, true);
+                LOG_INFO("BitChat Bridge: Registered direct neighbor 0x%08x (handle=%d)", senderId, bleConnHandle);
+            }
+        }
+    }
     
     // Sync time from BLE messages (they have accurate timestamps from phones)
     if (fromBLE && !timeSynced) {

--- a/src/modules/BitChatBridgeModule.cpp
+++ b/src/modules/BitChatBridgeModule.cpp
@@ -719,6 +719,7 @@ BitChatMessage BitChatBridgeModule::createPeerAnnouncement()
                 for (int b = 7; b >= 0; b--) {
                     msg.payload[offset++] = (id >> (b * 8)) & 0xFF;
                 }
+                LOG_DEBUG("BitChat Bridge: Announcement includes neighbor ID 0x%08x", (uint32_t)id);
             }
             LOG_DEBUG("BitChat Bridge: Added %d neighbors to announcement", neighborCount);
         } else {

--- a/src/modules/BitChatBridgeModule.cpp
+++ b/src/modules/BitChatBridgeModule.cpp
@@ -700,6 +700,32 @@ BitChatMessage BitChatBridgeModule::createPeerAnnouncement()
     memcpy(&msg.payload[offset], ed25519PublicKey, 32);
     offset += 32;
     
+    // TLV 4: Direct Neighbors (0x04 + Len + Count + IDs)
+    // Get neighbors from TopologyManager
+    uint64_t neighborIds[16]; // Max 16 neighbors to fit in payload
+    uint8_t neighborCount = topologyManager.getDirectNeighborIds(neighborIds, 16);
+    
+    if (neighborCount > 0) {
+        // Check if we have space: 2 bytes (Type+Len) + 1 byte (Count) + 8*count
+        size_t required = 3 + (neighborCount * 8);
+        if (offset + required <= BITCHAT_MAX_PAYLOAD_SIZE) {
+            msg.payload[offset++] = 0x04; // Type: neighbors
+            msg.payload[offset++] = 1 + (neighborCount * 8); // Length: Count byte + IDs
+            msg.payload[offset++] = neighborCount;
+            
+            for (uint8_t i = 0; i < neighborCount; i++) {
+                uint64_t id = neighborIds[i];
+                // Serialize 8-byte ID (Big Endian to match protocol)
+                for (int b = 7; b >= 0; b--) {
+                    msg.payload[offset++] = (id >> (b * 8)) & 0xFF;
+                }
+            }
+            LOG_DEBUG("BitChat Bridge: Added %d neighbors to announcement", neighborCount);
+        } else {
+            LOG_WARN("BitChat Bridge: Not enough space for neighbor list (%d bytes required)", required);
+        }
+    }
+    
     msg.payloadLength = offset;
     
     LOG_DEBUG("BitChat Bridge: Created announcement with TLV payload (%d bytes)", offset);

--- a/src/modules/BitChatBridgeModule.cpp
+++ b/src/modules/BitChatBridgeModule.cpp
@@ -710,8 +710,7 @@ BitChatMessage BitChatBridgeModule::createPeerAnnouncement()
         size_t required = 3 + (neighborCount * 8);
         if (offset + required <= BITCHAT_MAX_PAYLOAD_SIZE) {
             msg.payload[offset++] = 0x04; // Type: neighbors
-            msg.payload[offset++] = 1 + (neighborCount * 8); // Length: Count byte + IDs
-            msg.payload[offset++] = neighborCount;
+            msg.payload[offset++] = neighborCount * 8; // Length: IDs only
             
             for (uint8_t i = 0; i < neighborCount; i++) {
                 uint64_t id = neighborIds[i];

--- a/src/modules/BitChatBridgeModule.cpp
+++ b/src/modules/BitChatBridgeModule.cpp
@@ -163,10 +163,7 @@ int32_t BitChatBridgeModule::runOnce()
     #if !MESHTASTIC_EXCLUDE_BLUETOOTH
     if (bleEnabled && bleServiceSetup) {
         uint32_t currentTime = millis();
-        uint32_t announceInterval = bleBridge.isServiceActive() 
-                                    ? 5000  // 5 seconds when connected
-                                    : ANNOUNCE_INTERVAL_MS;  // 30 seconds when not connected
-        if (currentTime - lastAnnounceTime >= announceInterval) {
+        if (currentTime - lastAnnounceTime >= ANNOUNCE_INTERVAL_MS) {
             sendPeerAnnouncement();
             lastAnnounceTime = currentTime;
         }
@@ -217,7 +214,7 @@ void BitChatBridgeModule::queueMessageForProcessing(const BitChatMessage& msg, b
     messageQueueCount++;
 }
 
-void BitChatBridgeModule::processBitChatMessage(const BitChatMessage& msg, bool fromBLE)
+void BitChatBridgeModule::processBitChatMessage(BitChatMessage& msg, bool fromBLE)
 {
     logMessage(msg, fromBLE ? "BLE->Mesh" : "Mesh->BLE");
     
@@ -291,8 +288,12 @@ void BitChatBridgeModule::processBitChatMessage(const BitChatMessage& msg, bool 
     if (fromBLE) {
         relayToMesh(msg);
     } else {
-        broadcastToBLE(msg);
         messagesBridged++;
+    }
+
+    if (msg.ttl > 1) {
+        msg.decrementTtl();
+        broadcastToBLE(msg);
     }
 }
 

--- a/src/modules/BitChatBridgeModule.cpp
+++ b/src/modules/BitChatBridgeModule.cpp
@@ -234,7 +234,7 @@ void BitChatBridgeModule::processBitChatMessage(BitChatMessage& msg, bool fromBL
     if (fromBLE && msg.type == BITCHAT_MSG_ANNOUNCE) {
         // TTL=7 implies direct neighbor (0 hops)
         if (msg.ttl == 7) {
-            uint32_t senderId = msg.getSenderId32();
+            uint64_t senderId = msg.senderId;
             if (bleConnHandle != 0xFFFF) {
                 topologyManager.updateNeighbor(senderId, bleConnHandle, true);
                 LOG_INFO("BitChat Bridge: Registered direct neighbor 0x%08x (handle=%d)", senderId, bleConnHandle);
@@ -487,7 +487,7 @@ void BitChatBridgeModule::logMessage(const BitChatMessage& msg, const char* acti
     }
     
     LOG_DEBUG("BitChat Bridge: %s - Type: %s, Sender: 0x%08x, TTL: %d, Payload: %d bytes",
-              action, typeStr, msg.getSenderId32(), msg.ttl, msg.payloadLength);
+              action, typeStr, msg.senderId, msg.ttl, msg.payloadLength);
 }
 
 bool BitChatBridgeModule::handleConfigMessage(const meshtastic_AdminMessage* request, meshtastic_AdminMessage* response)
@@ -533,7 +533,7 @@ std::vector<BitChatMessage> BitChatBridgeModule::fragmentMessage(const BitChatMe
     for (uint8_t i = 0; i < totalFragments; i++) {
         BitChatMessage fragment;
         fragment.type = BITCHAT_MSG_FRAGMENT;
-        fragment.setSenderId32(msg.getSenderId32());
+        fragment.senderId = msg.senderId;
         fragment.timestamp = msg.timestamp;
         fragment.ttl = msg.ttl;
         
@@ -648,7 +648,7 @@ BitChatMessage BitChatBridgeModule::createPeerAnnouncement()
     BitChatMessage msg;
     
     msg.type = BITCHAT_MSG_ANNOUNCE;
-    msg.setSenderId32(myBitChatPeerId);
+    msg.senderId = static_cast<uint64_t>(myBitChatPeerId);
     // Timestamp in milliseconds since epoch (iOS format)
     // Use synced time if available, otherwise use device time (will be rejected by iOS)
     uint64_t deviceTimeMs = static_cast<uint64_t>(getTime()) * 1000ULL;

--- a/src/modules/BitChatBridgeModule.h
+++ b/src/modules/BitChatBridgeModule.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "SinglePortModule.h"
+#include "BitChatTopologyManager.h"
 #include "concurrency/OSThread.h"
 #include "mesh/MeshModule.h"
 #include <array>
@@ -21,15 +22,20 @@
 #endif
 
 // BitChat Protocol Constants
-#define BITCHAT_HEADER_SIZE 13  // Updated to match iOS format: version(1) + type(1) + ttl(1) + timestamp(8) + flags(1) + payloadLength(2) = 13
+#define BITCHAT_HEADER_SIZE_V1 13
+#define BITCHAT_HEADER_SIZE_V2 16
 #define BITCHAT_SIGNATURE_SIZE 64  // Ed25519 signature is 64 bytes
 #define BITCHAT_MAX_PAYLOAD_SIZE 245  // Increased to handle larger announcements
-#define BITCHAT_VERSION 1  // Protocol version (matches iOS)
+#define BITCHAT_VERSION 1
+#define BITCHAT_VERSION_1 1
+#define BITCHAT_VERSION_2 2
+#define BITCHAT_CURRENT_VERSION BITCHAT_VERSION_2
 #define BITCHAT_SERVICE_UUID "F47B5E2D-4A9E-4C5A-9B3F-8E1D2C3A4B5C"
 #define BITCHAT_CHARACTERISTIC_UUID "A1B2C3D4-E5F6-4A5B-8C9D-0E1F2A3B4C5D"
 #define BITCHAT_DUPLICATE_CACHE_SIZE 100
 #define BITCHAT_BLE_TIME_WINDOW_MS 30000  // 30 seconds - long enough to be discovered
 #define BITCHAT_BLE_INTERVAL_MS 35000     // 35 seconds between windows
+#define BITCHAT_MAX_HOPS 8                // Max hops for source routing
 
 // Fragmentation Constants
 #define BITCHAT_FRAGMENT_HEADER_SIZE 6    // fragment_id(2) + index(1) + total(1) + original_size(2)
@@ -65,6 +71,7 @@ enum BLEMode {
 #define BITCHAT_FLAG_HAS_RECIPIENT 0x01
 #define BITCHAT_FLAG_HAS_SIGNATURE 0x02
 #define BITCHAT_FLAG_IS_COMPRESSED 0x04
+#define BITCHAT_FLAG_HAS_ROUTE     0x08
 
 /**
  * BitChat Protocol Message Structure
@@ -75,12 +82,17 @@ struct BitChatMessage {
     uint8_t type;           // Message type (0x01-0x07)
     uint8_t ttl;            // Time to live
     uint64_t timestamp;     // Unix timestamp (8 bytes, milliseconds since epoch)
-    uint8_t flags;          // Flags: hasRecipient(0x01), hasSignature(0x02), isCompressed(0x04)
-    uint16_t payloadLength; // Length of payload (2 bytes)
+    uint8_t flags;          // Flags
+    uint32_t payloadLength; // Length of payload (4 bytes in V2)
     uint8_t senderId[8];    // Sender ID (8 bytes, padded)
     uint8_t recipientId[8]; // Recipient ID (8 bytes, optional, based on flags)
+    
+    // Source Routing (V2)
+    uint8_t routeCount;
+    uint64_t route[BITCHAT_MAX_HOPS]; // Intermediate hops
+    
     uint8_t payload[BITCHAT_MAX_PAYLOAD_SIZE]; // Message payload
-    uint8_t signature[BITCHAT_SIGNATURE_SIZE]; // Ed25519 signature (64 bytes, optional, based on flags)
+    uint8_t signature[BITCHAT_SIGNATURE_SIZE]; // Ed25519 signature
     
     // Helper to get senderId as uint32_t (for backward compatibility)
     uint32_t getSenderId32() const {
@@ -106,9 +118,10 @@ struct BitChatMessage {
     }
     
     // Constructor
-    BitChatMessage() : version(BITCHAT_VERSION), type(0), ttl(0), timestamp(0), flags(0), payloadLength(0) {
+    BitChatMessage() : version(BITCHAT_CURRENT_VERSION), type(0), ttl(0), timestamp(0), flags(0), payloadLength(0), routeCount(0) {
         memset(senderId, 0, sizeof(senderId));
         memset(recipientId, 0, sizeof(recipientId));
+        memset(route, 0, sizeof(route));
         memset(payload, 0, sizeof(payload));
         memset(signature, 0, sizeof(signature));
     }
@@ -210,14 +223,40 @@ private:
     bool serviceActive = false;
     
     // BLE write reassembly buffer (for handling MTU-limited writes from peripheral role)
-    // Buffer must accommodate: header(13) + sender(8) + recipient(8) + payload(245) + signature(64) = 338 bytes
-    static constexpr size_t BITCHAT_MAX_MESSAGE_SIZE = BITCHAT_HEADER_SIZE + 8 + 8 + BITCHAT_MAX_PAYLOAD_SIZE + BITCHAT_SIGNATURE_SIZE;
+    // Buffer must accommodate: header(13/16) + sender(8) + recipient(8) + route(var) + payload(245) + signature(64) = ~400 bytes
+    // Use slightly larger buffer to be safe
+    static constexpr size_t BITCHAT_MAX_MESSAGE_SIZE = 512;
     uint8_t writeBuffer[BITCHAT_MAX_MESSAGE_SIZE];
     size_t writeBufferOffset = 0;
     uint32_t lastWriteTime = 0;
     static constexpr uint32_t WRITE_TIMEOUT_MS = 5000; // Clear buffer if no write for 5 seconds
     
+    // Track connected handles for non-V2 NimBLE API workaround
+    std::vector<uint16_t> connectedHandles;
+    
 public:
+    void addConnection(uint16_t handle) {
+        if (std::find(connectedHandles.begin(), connectedHandles.end(), handle) == connectedHandles.end()) {
+            connectedHandles.push_back(handle);
+        }
+    }
+    
+    void removeConnection(uint16_t handle) {
+        auto it = std::remove(connectedHandles.begin(), connectedHandles.end(), handle);
+        connectedHandles.erase(it, connectedHandles.end());
+    }
+    
+    void clearConnections() {
+        connectedHandles.clear();
+    }
+    
+    uint16_t getSingleConnectionHandle() {
+        if (connectedHandles.size() == 1) {
+            return connectedHandles[0];
+        }
+        return 0xFFFF;
+    }
+
 #ifdef ARCH_ESP32
     bool setupBitChatService(NimBLEServer* server);
 #elif defined(ARCH_NRF52)
@@ -226,12 +265,13 @@ public:
     void startAdvertising();
     void stopAdvertising();
     void broadcastMessage(const BitChatMessage& msg);
+    void unicastMessage(uint16_t connHandle, const BitChatMessage& msg);
     bool isServiceActive() const { return serviceActive; }
     // Set bridge module reference for callbacks
     void setBridgeModule(class BitChatBridgeModule* module) { bridgeModule = module; }
     
     // BLE Callbacks - Peripheral Role (Server)
-    void onBitChatWrite(const uint8_t* data, size_t length);
+    void onBitChatWrite(const uint8_t* data, size_t length, uint16_t connHandle);
     void onBitChatConnect();
     void onBitChatDisconnect();
     void handleBitChatDisconnect(uint16_t connHandle, uint8_t reason);
@@ -260,6 +300,7 @@ private:
     // Core components
     BitChatDuplicateCache duplicateCache;
     FragmentReassemblyBuffer fragmentBuffer;
+    BitChatTopologyManager topologyManager; // Tracks direct neighbors
     uint16_t nextFragmentId = 1;  // Counter for generating unique fragment IDs
     
 #if !MESHTASTIC_EXCLUDE_BLUETOOTH
@@ -303,6 +344,7 @@ private:
     struct QueuedMessage {
         BitChatMessage msg;
         bool fromBLE;
+        uint16_t bleConnHandle;
     };
     static constexpr size_t MAX_QUEUE_SIZE = 8;
     QueuedMessage messageQueue[MAX_QUEUE_SIZE];
@@ -330,9 +372,10 @@ protected:
     
 public:
     // BitChat message handling
-    void processBitChatMessage(BitChatMessage& msg, bool fromBLE = false);
-    void queueMessageForProcessing(const BitChatMessage& msg, bool fromBLE); // Queue message for deferred processing
+    void processBitChatMessage(BitChatMessage& msg, bool fromBLE = false, uint16_t bleConnHandle = 0xFFFF);
+    void queueMessageForProcessing(const BitChatMessage& msg, bool fromBLE, uint16_t bleConnHandle = 0xFFFF); // Queue message for deferred processing
     void broadcastToBLE(const BitChatMessage& msg);
+    void unicastToBLE(uint16_t connHandle, const BitChatMessage& msg);
     void relayToMesh(const BitChatMessage& msg);
     
     // Configuration

--- a/src/modules/BitChatBridgeModule.h
+++ b/src/modules/BitChatBridgeModule.h
@@ -309,7 +309,8 @@ private:
     volatile size_t messageQueueHead = 0;  // Index of next message to process
     volatile size_t messageQueueTail = 0;  // Index of next free slot
     volatile size_t messageQueueCount = 0; // Number of messages in queue
-    
+    volatile bool shouldSendAnnouncement = false; // Flag to trigger announcement from main loop
+
 public:
     /** Constructor */
     BitChatBridgeModule();
@@ -350,6 +351,7 @@ public:
     
     // Peer announcement (public so BLE bridge can call on connection)
     void sendPeerAnnouncement();
+    void requestPeerAnnouncement();
     
 private:
     // Internal helpers

--- a/src/modules/BitChatBridgeModule.h
+++ b/src/modules/BitChatBridgeModule.h
@@ -98,6 +98,12 @@ struct BitChatMessage {
             senderId[i] = static_cast<uint8_t>((id >> (i * 8)) & 0xFF);
         }
     }
+
+    void decrementTtl() {
+        if (this->ttl > 1) {
+            this->ttl--;
+        }
+    }
     
     // Constructor
     BitChatMessage() : version(BITCHAT_VERSION), type(0), ttl(0), timestamp(0), flags(0), payloadLength(0) {
@@ -323,7 +329,7 @@ protected:
     
 public:
     // BitChat message handling
-    void processBitChatMessage(const BitChatMessage& msg, bool fromBLE = false);
+    void processBitChatMessage(BitChatMessage& msg, bool fromBLE = false);
     void queueMessageForProcessing(const BitChatMessage& msg, bool fromBLE); // Queue message for deferred processing
     void broadcastToBLE(const BitChatMessage& msg);
     void relayToMesh(const BitChatMessage& msg);

--- a/src/modules/BitChatBridgeModule.h
+++ b/src/modules/BitChatBridgeModule.h
@@ -84,8 +84,8 @@ struct BitChatMessage {
     uint64_t timestamp;     // Unix timestamp (8 bytes, milliseconds since epoch)
     uint8_t flags;          // Flags
     uint32_t payloadLength; // Length of payload (4 bytes in V2)
-    uint8_t senderId[8];    // Sender ID (8 bytes, padded)
-    uint8_t recipientId[8]; // Recipient ID (8 bytes, optional, based on flags)
+    uint64_t senderId;    // Sender ID (8 bytes, padded)
+    uint64_t recipientId; // Recipient ID (8 bytes, optional, based on flags)
     
     // Source Routing (V2)
     uint8_t routeCount;
@@ -94,21 +94,13 @@ struct BitChatMessage {
     uint8_t payload[BITCHAT_MAX_PAYLOAD_SIZE]; // Message payload
     uint8_t signature[BITCHAT_SIGNATURE_SIZE]; // Ed25519 signature
     
-    // Helper to get senderId as uint32_t (for backward compatibility)
-    uint32_t getSenderId32() const {
-        uint32_t id = 0;
-        for (int i = 0; i < 4; i++) {
-            id |= (static_cast<uint32_t>(senderId[i]) << (i * 8));
-        }
-        return id;
+    uint64_t getSenderId() const {
+        return this->senderId;
     }
     
     // Helper to set senderId from uint32_t
-    void setSenderId32(uint32_t id) {
-        memset(senderId, 0, 8);
-        for (int i = 0; i < 4; i++) {
-            senderId[i] = static_cast<uint8_t>((id >> (i * 8)) & 0xFF);
-        }
+    void setSenderId(uint64_t id) {
+        this->senderId = id;
     }
 
     void decrementTtl() {
@@ -119,8 +111,8 @@ struct BitChatMessage {
     
     // Constructor
     BitChatMessage() : version(BITCHAT_CURRENT_VERSION), type(0), ttl(0), timestamp(0), flags(0), payloadLength(0), routeCount(0) {
-        memset(senderId, 0, sizeof(senderId));
-        memset(recipientId, 0, sizeof(recipientId));
+        senderId = 0;
+        recipientId = 0;
         memset(route, 0, sizeof(route));
         memset(payload, 0, sizeof(payload));
         memset(signature, 0, sizeof(signature));

--- a/src/modules/BitChatDuplicateCache.cpp
+++ b/src/modules/BitChatDuplicateCache.cpp
@@ -11,7 +11,7 @@ uint32_t BitChatDuplicateCache::calculateHash(const BitChatMessage& msg)
     // This creates a unique fingerprint for each message
     
     struct HashData {
-        uint32_t senderId;
+        uint64_t senderId;
         uint32_t timestamp;
         uint8_t messageType;
         uint8_t payloadLength;
@@ -19,7 +19,7 @@ uint32_t BitChatDuplicateCache::calculateHash(const BitChatMessage& msg)
     } __attribute__((packed));
     
     HashData hashData = {};
-    hashData.senderId = msg.getSenderId32();
+    hashData.senderId = msg.senderId;
     // Use lower 32 bits of timestamp for hash (for backward compatibility)
     hashData.timestamp = static_cast<uint32_t>(msg.timestamp & 0xFFFFFFFFULL);
     hashData.messageType = msg.type;
@@ -54,7 +54,7 @@ bool BitChatDuplicateCache::isDuplicate(const BitChatMessage& msg)
     for (size_t i = 0; i < cache.size(); i++) {
         const auto& entry = cache[i];
         
-        uint32_t msgSenderId = msg.getSenderId32();
+        uint64_t msgSenderId = msg.senderId;
         uint32_t msgTimestamp32 = static_cast<uint32_t>(msg.timestamp & 0xFFFFFFFFULL);
         
         // Check for exact match
@@ -89,7 +89,7 @@ void BitChatDuplicateCache::addMessage(const BitChatMessage& msg)
     // Add message to cache using circular buffer
     auto& entry = cache[currentIndex];
     
-    entry.senderId = msg.getSenderId32();
+    entry.senderId = msg.senderId;
     // Use lower 32 bits of timestamp for cache (for backward compatibility)
     entry.timestamp = static_cast<uint32_t>(msg.timestamp & 0xFFFFFFFFULL);
     entry.messageType = msg.type;

--- a/src/modules/BitChatFragmentBuffer.cpp
+++ b/src/modules/BitChatFragmentBuffer.cpp
@@ -37,7 +37,7 @@ bool FragmentReassemblyBuffer::addFragment(const BitChatMessage& fragment, uint1
         memset(buffer->fragmentsReceived, 0, sizeof(buffer->fragmentsReceived));
         
         // Store original message metadata from first fragment
-        buffer->originalMessage.setSenderId32(fragment.getSenderId32());
+        buffer->originalMessage.senderId = fragment.senderId;
         buffer->originalMessage.timestamp = fragment.timestamp;
         buffer->originalMessage.ttl = fragment.ttl;
         
@@ -117,7 +117,7 @@ bool FragmentReassemblyBuffer::getReassembledMessage(uint16_t fragmentId, BitCha
             
             // Reconstruct original message
             outMsg.type = buffer.originalMessage.type;
-            outMsg.setSenderId32(buffer.originalMessage.getSenderId32());
+            outMsg.senderId = buffer.originalMessage.senderId;
             outMsg.timestamp = buffer.originalMessage.timestamp;
             outMsg.ttl = buffer.originalMessage.ttl;
             outMsg.payloadLength = buffer.originalSize;
@@ -132,7 +132,7 @@ bool FragmentReassemblyBuffer::getReassembledMessage(uint16_t fragmentId, BitCha
             memcpy(outMsg.payload, buffer.reassemblyBuffer, buffer.originalSize);
             
             LOG_INFO("BitChat Fragment: Reassembled message type 0x%02x, sender 0x%08x, %d bytes",
-                     outMsg.type, outMsg.getSenderId32(), outMsg.payloadLength);
+                     outMsg.type, outMsg.senderId, outMsg.payloadLength);
             
             // Clear buffer
             buffer.totalFragments = 0;

--- a/src/modules/BitChatProtocolHandler.cpp
+++ b/src/modules/BitChatProtocolHandler.cpp
@@ -1,5 +1,6 @@
 #include "BitChatBridgeModule.h"
 #include "configuration.h"
+#include "meshUtils.h"
 #include "mesh/MeshService.h"
 #include "mesh/Router.h"
 #include "NodeDB.h"
@@ -76,12 +77,12 @@ bool BitChatProtocolHandler::parseMessage(const uint8_t* data, size_t length, Bi
     
     // Sender ID
     msg.senderId = *reinterpret_cast<const uint64_t*>(data + offset);
-    offset += 8;
+    offset += sizeof(msg.senderId);
     
     // Recipient ID
     if (hasRecipient) {
         msg.recipientId = *reinterpret_cast<const uint64_t*>(data + offset);
-        offset += 8;
+        offset += sizeof(msg.recipientId);
     } else {
         msg.recipientId = 0;
     }
@@ -192,12 +193,12 @@ size_t BitChatProtocolHandler::serializeMessage(const BitChatMessage& msg, uint8
     }
     
     // Sender ID
-    memcpy(buffer + offset, &msg.senderId, 8);
+    memcpy(buffer + offset, &msg.senderId, sizeof(msg.senderId));
     offset += 8;
     
     // Recipient ID
     if (hasRecipient) {
-        memcpy(buffer + offset, &msg.recipientId, 8);
+        memcpy(buffer + offset, &msg.recipientId, sizeof(msg.recipientId));
         offset += 8;
     }
     
@@ -225,6 +226,7 @@ size_t BitChatProtocolHandler::serializeMessage(const BitChatMessage& msg, uint8
     }
     
     LOG_DEBUG("BitChat: Serialized V%d msg %d bytes (route=%d)", msg.version, offset, msg.routeCount);
+    printBytes("BitChat Outgoing", buffer, offset);
     return offset;
 }
 

--- a/src/modules/BitChatProtocolHandler.cpp
+++ b/src/modules/BitChatProtocolHandler.cpp
@@ -75,15 +75,15 @@ bool BitChatProtocolHandler::parseMessage(const uint8_t* data, size_t length, Bi
     }
     
     // Sender ID
-    memcpy(msg.senderId, data + offset, 8);
+    msg.senderId = *reinterpret_cast<const uint64_t*>(data + offset);
     offset += 8;
     
     // Recipient ID
     if (hasRecipient) {
-        memcpy(msg.recipientId, data + offset, 8);
+        msg.recipientId = *reinterpret_cast<const uint64_t*>(data + offset);
         offset += 8;
     } else {
-        memset(msg.recipientId, 0, 8);
+        msg.recipientId = 0;
     }
     
     // Source Route (V2 only)
@@ -192,12 +192,12 @@ size_t BitChatProtocolHandler::serializeMessage(const BitChatMessage& msg, uint8
     }
     
     // Sender ID
-    memcpy(buffer + offset, msg.senderId, 8);
+    memcpy(buffer + offset, &msg.senderId, 8);
     offset += 8;
     
     // Recipient ID
     if (hasRecipient) {
-        memcpy(buffer + offset, msg.recipientId, 8);
+        memcpy(buffer + offset, &msg.recipientId, 8);
         offset += 8;
     }
     
@@ -394,7 +394,7 @@ bool BitChatProtocolHandler::extractBitChatMessage(const meshtastic_MeshPacket& 
     }
     
     LOG_DEBUG("BitChat: Extracted message type=0x%02x, sender=0x%08x, ttl=%d, payload=%d bytes",
-              bitchatMsg.type, bitchatMsg.getSenderId32(), bitchatMsg.ttl, bitchatMsg.payloadLength);
+              bitchatMsg.type, bitchatMsg.senderId, bitchatMsg.ttl, bitchatMsg.payloadLength);
     
     return true;
 }

--- a/src/modules/BitChatProtocolHandler.cpp
+++ b/src/modules/BitChatProtocolHandler.cpp
@@ -12,48 +12,73 @@
 
 bool BitChatProtocolHandler::parseMessage(const uint8_t* data, size_t length, BitChatMessage& msg)
 {
-    if (!data || length < BITCHAT_HEADER_SIZE) {
-        LOG_WARN("BitChat: Invalid message - too short (%d bytes)", length);
+    if (!data || length < 1) {
+        LOG_WARN("BitChat: Invalid message - empty");
         return false;
     }
 
-    // Parse 13-byte BitChat header (iOS-compatible format)
-    size_t offset = 0;
+    // Peak at version (Byte 0)
+    uint8_t version = data[0];
+    size_t headerSize = 0;
     
-    // Byte 0: Version
-    msg.version = data[offset++];
-    if (msg.version != BITCHAT_VERSION) {
-        LOG_WARN("BitChat: Unsupported version %d (expected %d)", msg.version, BITCHAT_VERSION);
+    if (version == BITCHAT_VERSION_1) {
+        headerSize = BITCHAT_HEADER_SIZE_V1;
+    } else if (version == BITCHAT_VERSION_2) {
+        headerSize = BITCHAT_HEADER_SIZE_V2;
+    } else {
+        LOG_WARN("BitChat: Unsupported version %d", version);
         return false;
     }
     
-    // Byte 1: Message type
+    if (length < headerSize) {
+        LOG_WARN("BitChat: Invalid message - too short for header (%d < %d)", length, headerSize);
+        return false;
+    }
+
+    // Parse Fixed Header
+    size_t offset = 0;
+    msg.version = data[offset++];
     msg.type = data[offset++];
-    
-    // Byte 2: TTL
     msg.ttl = data[offset++];
     
-    // Bytes 3-10: Timestamp (8 bytes, big-endian)
+    // Timestamp (8 bytes)
     msg.timestamp = 0;
     for (int i = 0; i < 8; i++) {
         msg.timestamp = (msg.timestamp << 8) | static_cast<uint64_t>(data[offset++]);
     }
     
-    // Byte 11: Flags
     msg.flags = data[offset++];
+    
+    // Payload Length
+    if (version == BITCHAT_VERSION_2) {
+        msg.payloadLength = (static_cast<uint32_t>(data[offset]) << 24) |
+                            (static_cast<uint32_t>(data[offset + 1]) << 16) |
+                            (static_cast<uint32_t>(data[offset + 2]) << 8) |
+                            static_cast<uint32_t>(data[offset + 3]);
+        offset += 4;
+    } else {
+        msg.payloadLength = (static_cast<uint16_t>(data[offset]) << 8) | static_cast<uint16_t>(data[offset + 1]);
+        offset += 2;
+    }
+    
     bool hasRecipient = (msg.flags & BITCHAT_FLAG_HAS_RECIPIENT) != 0;
     bool hasSignature = (msg.flags & BITCHAT_FLAG_HAS_SIGNATURE) != 0;
+    bool hasRoute = (version >= BITCHAT_VERSION_2) && ((msg.flags & BITCHAT_FLAG_HAS_ROUTE) != 0);
     bool isCompressed = (msg.flags & BITCHAT_FLAG_IS_COMPRESSED) != 0;
     
-    // Bytes 12-13: Payload length (2 bytes, big-endian)
-    msg.payloadLength = (static_cast<uint16_t>(data[offset]) << 8) | static_cast<uint16_t>(data[offset + 1]);
-    offset += 2;
+    // Validate minimum remaining length
+    // SenderID (8) + RecipientID (opt 8) + Route (opt var) + Payload + Signature (opt 64)
+    size_t minRemaining = 8 + (hasRecipient ? 8 : 0) + (hasSignature ? BITCHAT_SIGNATURE_SIZE : 0) + msg.payloadLength;
+    if (length - offset < minRemaining) {
+        LOG_WARN("BitChat: Message truncated (expected at least %d more bytes, got %d)", minRemaining, length - offset);
+        return false;
+    }
     
-    // Bytes 14-21: Sender ID (8 bytes)
+    // Sender ID
     memcpy(msg.senderId, data + offset, 8);
     offset += 8;
     
-    // Bytes 22-29: Recipient ID (8 bytes, optional)
+    // Recipient ID
     if (hasRecipient) {
         memcpy(msg.recipientId, data + offset, 8);
         offset += 8;
@@ -61,22 +86,43 @@ bool BitChatProtocolHandler::parseMessage(const uint8_t* data, size_t length, Bi
         memset(msg.recipientId, 0, 8);
     }
     
-    // Validate payload length
+    // Source Route (V2 only)
+    msg.routeCount = 0;
+    if (hasRoute) {
+        // Read Count (1 byte)
+        if (offset >= length) return false;
+        uint8_t count = data[offset++];
+        
+        if (count > BITCHAT_MAX_HOPS) {
+             LOG_WARN("BitChat: Route too long (%d hops), truncating to %d", count, BITCHAT_MAX_HOPS);
+             LOG_WARN("BitChat: Route too long, rejecting");
+             return false;
+        }
+        
+        // Check size
+        if (length - offset < (size_t)(count * 8)) {
+            LOG_WARN("BitChat: Truncated route data");
+            return false;
+        }
+        
+        msg.routeCount = count;
+        for (int i = 0; i < count; i++) {
+            uint64_t hopId = 0;
+            for (int b = 0; b < 8; b++) {
+                hopId = (hopId << 8) | data[offset++];
+            }
+            msg.route[i] = hopId;
+        }
+    }
+    
+    // Validate payload length again vs MAX
     if (msg.payloadLength > BITCHAT_MAX_PAYLOAD_SIZE) {
         LOG_WARN("BitChat: Payload too large (%d bytes)", msg.payloadLength);
         return false;
     }
     
-    // Calculate minimum required length
-    size_t minLength = BITCHAT_HEADER_SIZE + 8 + (hasRecipient ? 8 : 0) + msg.payloadLength + (hasSignature ? BITCHAT_SIGNATURE_SIZE : 0);
-    if (length < minLength) {
-        LOG_WARN("BitChat: Message truncated (expected %d, got %d)", minLength, length);
-        return false;
-    }
-    
-    // Payload (with optional compression handling)
+    // Payload
     if (isCompressed) {
-        // For now, we don't support compression - log warning and fail
         LOG_WARN("BitChat: Compressed payload not supported yet");
         return false;
     }
@@ -85,14 +131,12 @@ bool BitChatProtocolHandler::parseMessage(const uint8_t* data, size_t length, Bi
         memcpy(msg.payload, data + offset, msg.payloadLength);
         offset += msg.payloadLength;
     }
-    
-    // Zero out remaining payload buffer
+    // Zero rest
     if (msg.payloadLength < BITCHAT_MAX_PAYLOAD_SIZE) {
-        memset(msg.payload + msg.payloadLength, 0, 
-               BITCHAT_MAX_PAYLOAD_SIZE - msg.payloadLength);
+         memset(msg.payload + msg.payloadLength, 0, BITCHAT_MAX_PAYLOAD_SIZE - msg.payloadLength);
     }
     
-    // Signature (64 bytes, optional)
+    // Signature
     if (hasSignature) {
         memcpy(msg.signature, data + offset, BITCHAT_SIGNATURE_SIZE);
         offset += BITCHAT_SIGNATURE_SIZE;
@@ -100,18 +144,23 @@ bool BitChatProtocolHandler::parseMessage(const uint8_t* data, size_t length, Bi
         memset(msg.signature, 0, BITCHAT_SIGNATURE_SIZE);
     }
     
-    LOG_DEBUG("BitChat: Parsed message type=0x%02x, sender=0x%08x, ttl=%d, payload=%d bytes, flags=0x%02x",
-              msg.type, msg.getSenderId32(), msg.ttl, msg.payloadLength, msg.flags);
-    
+    LOG_DEBUG("BitChat: Parsed V%d msg type=0x%02x, len=%d, route=%d hops", 
+              msg.version, msg.type, msg.payloadLength, msg.routeCount);
+              
     return true;
 }
 
 size_t BitChatProtocolHandler::serializeMessage(const BitChatMessage& msg, uint8_t* buffer, size_t maxLength)
 {
-    // Calculate required length
+    // Determine header size based on version
+    size_t headerSize = (msg.version >= BITCHAT_VERSION_2) ? BITCHAT_HEADER_SIZE_V2 : BITCHAT_HEADER_SIZE_V1;
+    
     bool hasRecipient = (msg.flags & BITCHAT_FLAG_HAS_RECIPIENT) != 0;
     bool hasSignature = (msg.flags & BITCHAT_FLAG_HAS_SIGNATURE) != 0;
-    size_t requiredLength = BITCHAT_HEADER_SIZE + 8 + (hasRecipient ? 8 : 0) + msg.payloadLength + (hasSignature ? BITCHAT_SIGNATURE_SIZE : 0);
+    bool hasRoute = (msg.version >= BITCHAT_VERSION_2) && ((msg.flags & BITCHAT_FLAG_HAS_ROUTE) != 0);
+    
+    size_t routeSize = hasRoute ? (1 + msg.routeCount * 8) : 0;
+    size_t requiredLength = headerSize + 8 + (hasRecipient ? 8 : 0) + routeSize + msg.payloadLength + (hasSignature ? BITCHAT_SIGNATURE_SIZE : 0);
     
     if (!buffer || maxLength < requiredLength) {
         return 0;
@@ -119,35 +168,48 @@ size_t BitChatProtocolHandler::serializeMessage(const BitChatMessage& msg, uint8
     
     size_t offset = 0;
     
-    // Byte 0: Version
+    // Header
     buffer[offset++] = msg.version;
-    
-    // Byte 1: Message type
     buffer[offset++] = msg.type;
-    
-    // Byte 2: TTL
     buffer[offset++] = msg.ttl;
     
-    // Bytes 3-10: Timestamp (8 bytes, big-endian)
+    // Timestamp (Big Endian)
     for (int i = 7; i >= 0; i--) {
         buffer[offset++] = static_cast<uint8_t>((msg.timestamp >> (i * 8)) & 0xFF);
     }
     
-    // Byte 11: Flags
     buffer[offset++] = msg.flags;
     
-    // Bytes 12-13: Payload length (2 bytes, big-endian)
-    buffer[offset++] = static_cast<uint8_t>((msg.payloadLength >> 8) & 0xFF);
-    buffer[offset++] = static_cast<uint8_t>(msg.payloadLength & 0xFF);
+    // Payload Length
+    if (msg.version >= BITCHAT_VERSION_2) {
+        buffer[offset++] = (msg.payloadLength >> 24) & 0xFF;
+        buffer[offset++] = (msg.payloadLength >> 16) & 0xFF;
+        buffer[offset++] = (msg.payloadLength >> 8) & 0xFF;
+        buffer[offset++] = msg.payloadLength & 0xFF;
+    } else {
+        buffer[offset++] = (msg.payloadLength >> 8) & 0xFF;
+        buffer[offset++] = msg.payloadLength & 0xFF;
+    }
     
-    // Bytes 14-21: Sender ID (8 bytes)
+    // Sender ID
     memcpy(buffer + offset, msg.senderId, 8);
     offset += 8;
     
-    // Bytes 22-29: Recipient ID (8 bytes, optional)
+    // Recipient ID
     if (hasRecipient) {
         memcpy(buffer + offset, msg.recipientId, 8);
         offset += 8;
+    }
+    
+    // Route (V2)
+    if (hasRoute) {
+        buffer[offset++] = msg.routeCount;
+        for (int i = 0; i < msg.routeCount; i++) {
+            uint64_t hop = msg.route[i];
+            for (int b = 7; b >= 0; b--) {
+                buffer[offset++] = (hop >> (b * 8)) & 0xFF;
+            }
+        }
     }
     
     // Payload
@@ -156,21 +218,21 @@ size_t BitChatProtocolHandler::serializeMessage(const BitChatMessage& msg, uint8
         offset += msg.payloadLength;
     }
     
-    // Signature (64 bytes, optional)
+    // Signature
     if (hasSignature) {
         memcpy(buffer + offset, msg.signature, BITCHAT_SIGNATURE_SIZE);
         offset += BITCHAT_SIGNATURE_SIZE;
     }
     
-    LOG_DEBUG("BitChat: Serialized message %d bytes (flags=0x%02x)", offset, msg.flags);
+    LOG_DEBUG("BitChat: Serialized V%d msg %d bytes (route=%d)", msg.version, offset, msg.routeCount);
     return offset;
 }
 
 bool BitChatProtocolHandler::validateMessage(const BitChatMessage& msg)
 {
     // Check version
-    if (msg.version != BITCHAT_VERSION) {
-        LOG_WARN("BitChat: Invalid version %d (expected %d)", msg.version, BITCHAT_VERSION);
+    if (msg.version != BITCHAT_VERSION_1 && msg.version != BITCHAT_VERSION_2) {
+        LOG_WARN("BitChat: Invalid version %d", msg.version);
         return false;
     }
     
@@ -251,9 +313,13 @@ meshtastic_MeshPacket* BitChatProtocolHandler::createMeshtasticPacket(const BitC
     const uint32_t BITCHAT_MAGIC = 0x42434854; // "BCHT"
     
     // Calculate actual message size (same calculation as serializeMessage)
+    size_t headerSize = (bitchatMsg.version >= BITCHAT_VERSION_2) ? BITCHAT_HEADER_SIZE_V2 : BITCHAT_HEADER_SIZE_V1;
     bool hasRecipient = (bitchatMsg.flags & BITCHAT_FLAG_HAS_RECIPIENT) != 0;
     bool hasSignature = (bitchatMsg.flags & BITCHAT_FLAG_HAS_SIGNATURE) != 0;
-    size_t messageSize = BITCHAT_HEADER_SIZE + 8 + (hasRecipient ? 8 : 0) + bitchatMsg.payloadLength + (hasSignature ? BITCHAT_SIGNATURE_SIZE : 0);
+    bool hasRoute = (bitchatMsg.version >= BITCHAT_VERSION_2) && ((bitchatMsg.flags & BITCHAT_FLAG_HAS_ROUTE) != 0);
+    size_t routeSize = hasRoute ? (1 + bitchatMsg.routeCount * 8) : 0;
+    
+    size_t messageSize = headerSize + 8 + (hasRecipient ? 8 : 0) + routeSize + bitchatMsg.payloadLength + (hasSignature ? BITCHAT_SIGNATURE_SIZE : 0);
     size_t totalSize = sizeof(BITCHAT_MAGIC) + messageSize;
     
     if (totalSize > sizeof(packet->decoded.payload.bytes)) {
@@ -303,7 +369,7 @@ bool BitChatProtocolHandler::extractBitChatMessage(const meshtastic_MeshPacket& 
     
     // Check for minimum size (magic + header)
     const uint32_t BITCHAT_MAGIC = 0x42434854; // "BCHT"
-    if (meshPacket.decoded.payload.size < sizeof(BITCHAT_MAGIC) + BITCHAT_HEADER_SIZE) {
+    if (meshPacket.decoded.payload.size < sizeof(BITCHAT_MAGIC) + 1) { // At least magic + version
         return false;
     }
     

--- a/src/modules/BitChatProtocolHandler.cpp
+++ b/src/modules/BitChatProtocolHandler.cpp
@@ -76,12 +76,12 @@ bool BitChatProtocolHandler::parseMessage(const uint8_t* data, size_t length, Bi
     }
     
     // Sender ID
-    msg.senderId = *reinterpret_cast<const uint64_t*>(data + offset);
+    memcpy(&msg.senderId, data + offset, sizeof(msg.senderId));
     offset += sizeof(msg.senderId);
     
     // Recipient ID
     if (hasRecipient) {
-        msg.recipientId = *reinterpret_cast<const uint64_t*>(data + offset);
+        memcpy(&msg.recipientId, data + offset, sizeof(msg.recipientId));
         offset += sizeof(msg.recipientId);
     } else {
         msg.recipientId = 0;

--- a/src/modules/BitChatTopologyManager.cpp
+++ b/src/modules/BitChatTopologyManager.cpp
@@ -1,0 +1,42 @@
+#include "BitChatTopologyManager.h"
+#include "configuration.h" // For millis() usually, or Arduino.h
+
+void BitChatTopologyManager::updateNeighbor(uint32_t peerId, uint16_t connHandle, bool isDirect) {
+    uint32_t currentTime = millis();
+    neighbors[peerId] = NeighborInfo(connHandle, currentTime, isDirect);
+}
+
+bool BitChatTopologyManager::getNeighbor(uint32_t peerId, NeighborInfo& info) {
+    auto it = neighbors.find(peerId);
+    if (it != neighbors.end()) {
+        info = it->second;
+        return true;
+    }
+    return false;
+}
+
+void BitChatTopologyManager::removeNeighbor(uint32_t peerId) {
+    neighbors.erase(peerId);
+}
+
+void BitChatTopologyManager::cleanup(uint32_t currentTime) {
+    auto it = neighbors.begin();
+    while (it != neighbors.end()) {
+        if (currentTime - it->second.lastHeard > NEIGHBOR_TIMEOUT_MS) {
+            it = neighbors.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+uint8_t BitChatTopologyManager::getDirectNeighborIds(uint64_t* outIds, uint8_t maxCount) {
+    uint8_t count = 0;
+    for (const auto& pair : neighbors) {
+        if (pair.second.isDirect && count < maxCount) {
+            // Promote 32-bit ID to 64-bit for protocol V2
+            outIds[count++] = (uint64_t)pair.first;
+        }
+    }
+    return count;
+}

--- a/src/modules/BitChatTopologyManager.cpp
+++ b/src/modules/BitChatTopologyManager.cpp
@@ -1,7 +1,7 @@
 #include "BitChatTopologyManager.h"
 #include "configuration.h" // For millis() usually, or Arduino.h
 
-void BitChatTopologyManager::updateNeighbor(uint32_t peerId, uint16_t connHandle, bool isDirect) {
+void BitChatTopologyManager::updateNeighbor(uint64_t peerId, uint16_t connHandle, bool isDirect) {
     uint32_t currentTime = millis();
     neighbors[peerId] = NeighborInfo(connHandle, currentTime, isDirect);
 }

--- a/src/modules/BitChatTopologyManager.h
+++ b/src/modules/BitChatTopologyManager.h
@@ -1,0 +1,34 @@
+#pragma once
+#include <map>
+#include <stdint.h>
+
+/**
+ * Manages the topology of directly connected BitChat peers
+ * primarily for BLE Source Routing (unicast)
+ */
+class BitChatTopologyManager {
+public:
+    struct NeighborInfo {
+        uint16_t connHandle;      // BLE Connection Handle
+        uint32_t lastHeard;       // Timestamp (millis)
+        bool isDirect;            // True if TTL=7
+        
+        NeighborInfo() : connHandle(0xFFFF), lastHeard(0), isDirect(false) {}
+        NeighborInfo(uint16_t handle, uint32_t time, bool direct) 
+            : connHandle(handle), lastHeard(time), isDirect(direct) {}
+    };
+
+private:
+    std::map<uint32_t, NeighborInfo> neighbors; // PeerID -> Info
+    static constexpr uint32_t NEIGHBOR_TIMEOUT_MS = 60000; // 1 minute timeout
+
+public:
+    void updateNeighbor(uint32_t peerId, uint16_t connHandle, bool isDirect);
+    bool getNeighbor(uint32_t peerId, NeighborInfo& info);
+    void removeNeighbor(uint32_t peerId);
+    void cleanup(uint32_t currentTime);
+    
+    // Get list of direct neighbors for ANNOUNCE packet
+    // returns count, fills array up to maxCount
+    uint8_t getDirectNeighborIds(uint64_t* outIds, uint8_t maxCount);
+};

--- a/src/modules/BitChatTopologyManager.h
+++ b/src/modules/BitChatTopologyManager.h
@@ -19,11 +19,11 @@ public:
     };
 
 private:
-    std::map<uint32_t, NeighborInfo> neighbors; // PeerID -> Info
+    std::map<uint64_t, NeighborInfo> neighbors; // PeerID -> Info
     static constexpr uint32_t NEIGHBOR_TIMEOUT_MS = 60000; // 1 minute timeout
 
 public:
-    void updateNeighbor(uint32_t peerId, uint16_t connHandle, bool isDirect);
+    void updateNeighbor(uint64_t peerId, uint16_t connHandle, bool isDirect);
     bool getNeighbor(uint32_t peerId, NeighborInfo& info);
     void removeNeighbor(uint32_t peerId);
     void cleanup(uint32_t currentTime);

--- a/variants/esp32s3/heltec_wireless_tracker/platformio.ini
+++ b/variants/esp32s3/heltec_wireless_tracker/platformio.ini
@@ -10,7 +10,9 @@ build_flags =
   -D HELTEC_TRACKER_V1_1
   -D GPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
   ;-D DEBUG_DISABLED ; uncomment this line to disable DEBUG output
+  -D NIMBLE_TWO
 
 lib_deps =
   ${esp32s3_base.lib_deps}
   lovyan03/LovyanGFX@^1.2.0
+  h2zero/NimBLE-Arduino@^2.2.3


### PR DESCRIPTION
This PR adds: 

* Relay from BLE -> to BLE (with decreased TTL) so the device acts just like any other bluetooth mesh participant
* Unicasts to specific bluetooth handle and source based routing (v2 packets: https://github.com/permissionlesstech/bitchat-android/blob/main/docs/SOURCE_ROUTING.md). Still only broadcasts on the LoRa network, we don't assume anything of the topology of the radio network.

In order to surface a bluetooth handle i had enable the NIMBLE_V2 flag and bump the dependency. Without it, it still works but can't do bluetooth unicasts so it falls back to broadcast.