### PR TITLE
Feature/lower channel utilization

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(ls:*)",
+      "Bash(ln:*)"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,8 @@
   "permissions": {
     "allow": [
       "Bash(ls:*)",
-      "Bash(ln:*)"
+      "Bash(ln:*)",
+      "Bash(pio run:*)"
     ]
   }
 }

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,119 @@
+# AI Agent Context — firmware-bitchat-plugin
+
+## Project Overview
+
+This is a **Meshtastic firmware fork** with a custom **BitChat BLE-to-LoRa bridge plugin**. The plugin bridges BitChat's Bluetooth Low Energy protocol (~100m range) over Meshtastic's LoRa mesh network (15km+ per hop). Meshtastic devices act as both relay bridges and full BitChat peers. BitChat mobile apps (iOS/Android) require zero modifications.
+
+```
+BitChat App <-> BLE <-> Meshtastic Node (Plugin) <-> LoRa Mesh <-> Remote Node <-> BLE <-> BitChat App
+  [100m]                  [Bridge/Peer]             [15km+]         [Bridge/Peer]          [100m]
+```
+
+Most of the 713+ source files are upstream Meshtastic. The BitChat plugin is the custom code.
+
+## Two Target Architectures
+
+|                      | ESP32                                  | nRF52                                      |
+|----------------------|----------------------------------------|--------------------------------------------|
+| **Arch macro**       | `ARCH_ESP32`                           | `ARCH_NRF52`                               |
+| **BLE stack**        | NimBLE (`<NimBLEDevice.h>`)            | Bluefruit (`<bluefruit.h>`)                |
+| **Platform dir**     | `src/platform/esp32/`                  | `src/platform/nrf52/`                      |
+| **Arch config**      | `arch/esp32/esp32.ini`                 | `arch/nrf52/nrf52.ini`                     |
+| **WiFi**             | Yes                                    | No                                         |
+| **Crypto**           | Software (rweather/Crypto)             | Hardware accelerated                       |
+| **BLE service init** | `setupBitChatService(NimBLEServer*)`   | `setupBitChatService()` (no args)          |
+| **Mutex**            | `std::mutex` available                 | NOT available                              |
+| **Excluded features**| Fewer exclusions                       | No WiFi, HTTP, audio, paxcounter           |
+| **Example boards**   | tbeam, heltec_v1/v2/v3, tlora, t-deck | rak4631, t-echo, canaryone, heltec pocket  |
+
+**Critical**: Any BLE code MUST be wrapped in `#ifdef ARCH_ESP32` / `#elif defined(ARCH_NRF52)` blocks. Never mix NimBLE and Bluefruit APIs. Both paths must compile independently. Never use `std::mutex` inside nRF52 code paths.
+
+## BitChat Plugin Source Files (the custom code)
+
+### Core plugin files (6 files):
+- `src/modules/BitChatBridgeModule.h` — Header: all structs, classes, constants, protocol definitions
+- `src/modules/BitChatBridgeModule.cpp` — Main module: setup, runOnce loop, message routing, Ed25519 signing, fragmentation
+- `src/modules/BitChatBLEBridge.cpp` — BLE service: platform-split ESP32/nRF52 implementations, notification broadcasting, write reassembly
+- `src/modules/BitChatProtocolHandler.cpp` — Binary protocol parsing/serialization, Meshtastic packet wrapping/unwrapping
+- `src/modules/BitChatDuplicateCache.cpp` — FNV-1a hash duplicate detection with circular buffer
+- `src/modules/BitChatFragmentBuffer.cpp` — Fragment reassembly with timeout cleanup
+
+### Modified Meshtastic files:
+- `src/BluetoothCommon.h/.cpp` — Exports `BITCHAT_SERVICE_UUID_16` and `BITCHAT_CHARACTERISTIC_UUID_16`
+- `src/nimble/NimbleBluetooth.cpp` — ESP32 BLE integration (gated by `!MESHTASTIC_EXCLUDE_BITCHAT_BRIDGE`)
+- `src/platform/nrf52/NRF52Bluetooth.cpp` — nRF52 BLE integration (same gate)
+- `src/modules/Modules.cpp` — Registers `bitchatBridgeModule` in the module list
+- `src/configuration.h` — Feature flag: `MESHTASTIC_EXCLUDE_BITCHAT_BRIDGE`
+
+## BitChat Protocol Format
+
+```
+Header (13 bytes): version(1) | type(1) | TTL(1) | timestamp(8) | flags(1) | payloadLength(2)
+Body:              senderID(8) | [recipientID(8)] | payload(N) | [signature(64)]
+Meshtastic wrap:   magic "BCHT"(4) | full BitChat message
+```
+
+- **Flags**: `0x01` = has recipient, `0x02` = has signature, `0x04` = compressed
+- **Message types**: ANNOUNCE(0x01), MESSAGE(0x02), LEAVE(0x03), IDENTITY(0x04), CHANNEL(0x05), PING(0x06), PONG(0x07), NOISE_HANDSHAKE(0x10), NOISE_ENCRYPTED(0x11), FRAGMENT_NEW(0x20), REQUEST_SYNC(0x21), FILE_TRANSFER(0x22), FRAGMENT(0xFF)
+- **Announcement TLV payload**: 0x01=nickname, 0x02=Noise pubkey(32B), 0x03=Ed25519 signing pubkey(32B)
+- **Signature**: Ed25519 over serialized message with TTL=0, PKCS#7 padded to block boundary (matching Android BinaryProtocol format)
+
+## Build System
+
+PlatformIO-based. Key commands:
+
+```bash
+# Build for specific board
+pio run -e tbeam          # ESP32
+pio run -e rak4631        # nRF52
+
+# Build all ESP32 targets
+bin/build-esp32.sh
+
+# Build all nRF52 targets
+bin/build-nrf52.sh
+```
+
+- Architecture configs: `arch/esp32/esp32.ini`, `arch/nrf52/nrf52.ini`
+- Board variants: `variants/<arch>/<board>/`
+- Disable plugin: uncomment `#define MESHTASTIC_EXCLUDE_BITCHAT_BRIDGE 1` in `src/configuration.h`
+
+## Coding Conventions
+
+- **Logging**: Use `LOG_INFO()`, `LOG_DEBUG()`, `LOG_WARN()`, `LOG_ERROR()` — never `Serial.println()`
+- **Log prefixes**: `"BitChat Bridge:"`, `"BitChat BLE:"`, `"BitChat Fragment:"`, `"BitChat:"`
+- **Module pattern**: Extend `SinglePortModule` for mesh messages; use `meshtastic_PortNum_PRIVATE_APP`
+- **Threading**: Use `concurrency::OSThread` with `runOnce()` for periodic tasks
+- **Memory**: Fixed-size arrays preferred over dynamic allocation. Circular buffers for caches/queues. Especially constrained on nRF52.
+- **BLE callbacks**: Limited stack — queue messages via `queueMessageForProcessing()`, process in `runOnce()`
+- **Timestamps**: Milliseconds since Unix epoch (`uint64_t`), matching iOS/Android BitChat format
+- **Peer ID**: Derived from `nodeDB->getNodeNum()` — stable across reboots
+- **Crypto**: Ed25519 via `rweather/Crypto` library (`<Ed25519.h>`, `<RNG.h>`)
+- **Non-interference**: Plugin must not break existing Meshtastic BLE, Serial, or mesh routing
+
+## Key Meshtastic APIs
+
+```cpp
+router->allocForSending()                    // Allocate mesh packet
+service->sendToMesh(packet, RX_SRC_LOCAL)    // Send to mesh
+nodeDB->getNodeNum()                         // Local node ID
+owner.long_name                              // Device display name
+config.bluetooth.enabled                     // BLE enabled check
+getTime()                                    // Device time (seconds since epoch)
+millis()                                     // Uptime (milliseconds)
+packetPool.release(packet)                   // Free packet on error
+```
+
+## Testing
+
+- Flash firmware, connect BitChat iOS/Android app via BLE
+- Verify "people nearby" counter increments on the app
+- Check serial logs for `"BitChat Bridge:"` prefixed messages
+- Startup logs: `"Setting up module"`, `"Acting as peer ID 0x..."`, `"Module setup complete"`
+- Announcements every 30 seconds in logs
+
+## Documentation
+
+- `BITCHAT_PLUGIN.md` — Full plugin documentation
+- `MESHTASTIC_PEER_ANNOUNCEMENT.md` — Peer announcement protocol details
+- `RELEASE_README.md` — Release instructions with board support matrix

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/modules/BitChatBridgeModule.cpp
+++ b/src/modules/BitChatBridgeModule.cpp
@@ -289,6 +289,10 @@ void BitChatBridgeModule::processBitChatMessage(const BitChatMessage& msg, bool 
     }
     
     if (fromBLE) {
+        // Rate-limit announcements to avoid flooding LoRa mesh
+        if (msg.type == BITCHAT_MSG_ANNOUNCE && isAnnouncementRateLimited(msg)) {
+            return;
+        }
         relayToMesh(msg);
     } else {
         broadcastToBLE(msg);
@@ -426,6 +430,51 @@ bool BitChatBridgeModule::shouldRelayMessage(const BitChatMessage& msg)
             LOG_WARN("BitChat Bridge: Unknown message type 0x%02x", msg.type);
             return false;
     }
+}
+
+bool BitChatBridgeModule::isAnnouncementRateLimited(const BitChatMessage& msg)
+{
+    uint32_t senderId = msg.getSenderId32();
+    uint32_t now = millis();
+
+    // Check if we already have an entry for this sender
+    for (size_t i = 0; i < announceRateLimitCount; i++) {
+        if (announceRateLimit[i].senderId == senderId) {
+            uint32_t elapsed = now - announceRateLimit[i].lastRelayTime;
+            if (elapsed < ANNOUNCE_RELAY_INTERVAL_MS) {
+                LOG_DEBUG("BitChat Bridge: Rate-limiting announcement from 0x%08x (%d seconds until next relay)",
+                          senderId, (ANNOUNCE_RELAY_INTERVAL_MS - elapsed) / 1000);
+                return true; // Rate-limited
+            }
+            // Interval passed — allow relay and update timestamp
+            announceRateLimit[i].lastRelayTime = now;
+            LOG_INFO("BitChat Bridge: Relaying announcement from 0x%08x to mesh (rate-limit interval passed)", senderId);
+            return false;
+        }
+    }
+
+    // New sender — add entry
+    if (announceRateLimitCount < MAX_RATE_LIMIT_ENTRIES) {
+        announceRateLimit[announceRateLimitCount].senderId = senderId;
+        announceRateLimit[announceRateLimitCount].lastRelayTime = now;
+        announceRateLimitCount++;
+    } else {
+        // Table full — evict oldest entry
+        uint32_t oldestTime = now;
+        size_t oldestIdx = 0;
+        for (size_t i = 0; i < MAX_RATE_LIMIT_ENTRIES; i++) {
+            uint32_t age = now - announceRateLimit[i].lastRelayTime;
+            if (age > (now - oldestTime)) {
+                oldestTime = announceRateLimit[i].lastRelayTime;
+                oldestIdx = i;
+            }
+        }
+        announceRateLimit[oldestIdx].senderId = senderId;
+        announceRateLimit[oldestIdx].lastRelayTime = now;
+    }
+
+    LOG_INFO("BitChat Bridge: Relaying first announcement from 0x%08x to mesh", senderId);
+    return false; // First time — allow relay
 }
 
 void BitChatBridgeModule::updateStatistics()

--- a/src/modules/BitChatBridgeModule.h
+++ b/src/modules/BitChatBridgeModule.h
@@ -290,6 +290,17 @@ private:
     uint8_t ed25519PublicKey[32];     // Ed25519 public key (32 bytes)
     bool ed25519KeysInitialized = false; // Track if keys have been generated/loaded
     
+    // Rate-limiting for announcements relayed BLE->Mesh (per sender)
+    // Only relay one announcement per sender every ANNOUNCE_RELAY_INTERVAL_MS
+    struct AnnouncementRateEntry {
+        uint32_t senderId;
+        uint32_t lastRelayTime; // millis()
+    };
+    static constexpr size_t MAX_RATE_LIMIT_ENTRIES = 16;
+    static constexpr uint32_t ANNOUNCE_RELAY_INTERVAL_MS = 300000; // 5 minutes
+    AnnouncementRateEntry announceRateLimit[MAX_RATE_LIMIT_ENTRIES];
+    size_t announceRateLimitCount = 0;
+
     // Message queue for deferring heavy processing from BLE callbacks to main loop
     // BLE callbacks have limited stack, so we queue messages and process them in runOnce()
     // Use simple fixed-size circular buffer (no dynamic allocation, safe for early initialization)
@@ -348,6 +359,7 @@ public:
 private:
     // Internal helpers
     bool shouldRelayMessage(const BitChatMessage& msg);
+    bool isAnnouncementRateLimited(const BitChatMessage& msg);
     void updateStatistics();
     void logMessage(const BitChatMessage& msg, const char* action);
     


### PR DESCRIPTION
Add ai rules files
Rate limit bitchat lora announcements to 5 minutes

With 6 devices: android, ipad, ios, heltecv3, rak4631, rak4631, my channel utilization has gone from ~53% to 4% while idle.    

https://github.com/evansmj/firmware-bitchat-plugin/issues/6